### PR TITLE
refactor: drop use of Map in favour of sparse array

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,5 @@
 /* eslint-env mocha */
 require('core-js/es6/weak-map')
-require('core-js/es6/map')
 var polyfillEventTarget = require('../src')
 var assert = require('assert')
 


### PR DESCRIPTION
The sparse array requires less polyfills, and can be used with simpler
mechanisms (like a for loop vs forEach call).

This cribs the chmod octal notation concept - where each option is
assigned a binary number and so we can quickly AND to check which
options have been turned on and which have been turned off. e.g.:

  0001 -> passive
  0010 -> once
  0100 -> capture
  0011 -> passive & once
  0110 -> passive & capture
  0111 -> passive & once & capture

  `0001 & 4` -> returns 0 - options does not feature `capture`
  `0011 & 4` -> returns 0 - options does not feature `capture`
  `0111 & 4` -> returns 4 - options does have `capture` option