### PR TITLE
fix bug for multiple event listeners

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,10 @@ var enhance = module.exports = function enhance(proto) {
 
   var listeners = new WeakMap()
   proto.addEventListener = function(name, originalCallback, optionsOrCapture) {
+    if (optionsOrCapture === undefined || optionsOrCapture === true || optionsOrCapture === false) {
+      return originalAddEventListener.call(this, name, originalCallback, optionsOrCapture)
+    }
+
     var callback = originalCallback
     var options = typeof optionsOrCapture === 'boolean' ? {capture: optionsOrCapture} : optionsOrCapture || {}
     var passive = Boolean(options.passive)
@@ -50,9 +54,9 @@ var enhance = module.exports = function enhance(proto) {
     var capture = Boolean(typeof optionsOrCapture === 'object' ? optionsOrCapture.capture : optionsOrCapture)
 
     var elementMap = listeners.get(this)
-    if (!elementMap) return
+    if (!elementMap) return originalRemoveEventListener.call(this, name, originalCallback, optionsOrCapture)
     var callbacks = elementMap.get(originalCallback)
-    if (!callbacks) return
+    if (!callbacks) return originalRemoveEventListener.call(this, name, originalCallback, optionsOrCapture)
 
     for (var optionsOctal in callbacks) {
       var callbackIsCapture = Boolean(optionsOctal & 4)

--- a/test/index.js
+++ b/test/index.js
@@ -31,6 +31,14 @@ function testSuite(eventTarget) {
         eventTarget.dispatchEvent(event('test2'))
         assert.equal(i, 2, 'test1 event listener was not unbound properly and fired ' + i + ' times')
       })
+
+      it('can bind and unbind simple event listeners', function() {
+        eventTarget.addEventListener('test', increment)
+        eventTarget.dispatchEvent(event('test'))
+        eventTarget.removeEventListener('test', increment)
+        eventTarget.dispatchEvent(event('test'))
+        assert.equal(i, 1, 'test event listener was not unbound properly and fired ' + i + ' times')
+      })
     })
 
     describe('once option', function() {


### PR DESCRIPTION
This fixes a bug we've noticed where binding multiple event listeners with the same function reference caused later unbindings to not properly unbind.

In addition to these work @mislav noticed an optimisation case where we can simply call add/removeEventListener if we're passed "simple options" (i.e. no options, or `true` or `false`). We attempted further optimisation by checking to see if `capture` was the only true option but this didn't work - so as far as we can see this is the best-case optimisation.

/cc @github/web-systems 